### PR TITLE
cluster style - resize map - responsive

### DIFF
--- a/spana-app/web/IWAD-app/src/app/components/home/home.html
+++ b/spana-app/web/IWAD-app/src/app/components/home/home.html
@@ -12,10 +12,8 @@
                 and the importance of caring for working animals.<br><br> Thank you to all of our kind and generous supporters,
                 we’re looking forward to hearing from you!</p>
         </div>
-        <div class="row">
-            <div class="col-xs-12 col-md-6">
-                <img class="donkey" src="assets/imgs/DSC05566.jpg" width="100%">
-            </div>
+        <div class="col-xs-12 col-md-6">
+            <img class="donkey" src="assets/imgs/DSC05566.jpg" width="100%">
         </div>
     </div>
     <div class="row text-center">

--- a/spana-app/web/IWAD-app/src/app/components/home/home.scss
+++ b/spana-app/web/IWAD-app/src/app/components/home/home.scss
@@ -54,18 +54,29 @@ h3 {
   margin-top: 20px;
 }
 
+.donkey {
+  margin-bottom: 20px;
+  margin-top: 5px;
+  border-radius: 6px;
+  text-decoration: none;
+  box-shadow: 2px 2px 3px black;
+}
+
+@media only screen and (max-width: 350px) {
+    .button {
+      font-size: 0.8em;
+    }
+}
+
 @media only screen and (max-width: 500px) {
     .logo {
       width: 280px;
     }
 }
 
-.donkey {
-  width: 450px;
-  height: 350px;
-  margin-bottom: 20px;
-  margin-top: 5px;
-  border-radius: 6px;
-  text-decoration: none;
-  box-shadow: 2px 2px 3px black;
+@media only screen and (min-width: 992px) {
+    .donkey {
+      width: 450px;
+      height: 350px;
+    }
 }

--- a/spana-app/web/IWAD-app/src/app/components/map/map.scss
+++ b/spana-app/web/IWAD-app/src/app/components/map/map.scss
@@ -1,3 +1,27 @@
+.marker-cluster-small, .marker-cluster-small div, .marker-cluster-medium, .marker-cluster-medium div,
+.marker-cluster-large, .marker-cluster-large div {
+	background-color: transparent !important;
+	}
+// .marker-cluster-small div {
+//   background-color: transparent !important;
+//   // background-image: '/assets/imgs/heart-icon.png' !important;
+// 	}
+
+// .marker-cluster-medium {
+//   background-color: transparent !important;
+// 	}
+// .marker-cluster-medium div {
+// 	background-color: transparent !important;
+// 	}
+
+// .marker-cluster-large {
+// background-color: transparent !important;
+// 	}
+// .marker-cluster-large div {
+// background-color: transparent !important;
+// 	}
+
+
 #mapid {
   width: 650px;
   height: 800px;

--- a/spana-app/web/IWAD-app/src/app/components/map/map.scss
+++ b/spana-app/web/IWAD-app/src/app/components/map/map.scss
@@ -1,27 +1,3 @@
-.marker-cluster-small, .marker-cluster-small div, .marker-cluster-medium, .marker-cluster-medium div,
-.marker-cluster-large, .marker-cluster-large div {
-	background-color: transparent !important;
-	}
-// .marker-cluster-small div {
-//   background-color: transparent !important;
-//   // background-image: '/assets/imgs/heart-icon.png' !important;
-// 	}
-
-// .marker-cluster-medium {
-//   background-color: transparent !important;
-// 	}
-// .marker-cluster-medium div {
-// 	background-color: transparent !important;
-// 	}
-
-// .marker-cluster-large {
-// background-color: transparent !important;
-// 	}
-// .marker-cluster-large div {
-// background-color: transparent !important;
-// 	}
-
-
 #mapid {
   width: 650px;
   height: 800px;
@@ -39,7 +15,19 @@
   padding-right: 20px;
 }
 
-@media only screen and (max-width: 1400px) {
+.marker-cluster-small, .marker-cluster-small div, .marker-cluster-medium, .marker-cluster-medium div,
+.marker-cluster-large, .marker-cluster-large div {
+	background-color: transparent;
+}
+
+/* IE 6-8 fallback colors */
+.leaflet-oldie .marker-cluster-small, .leaflet-oldie .marker-cluster-small div, 
+.leaflet-oldie .marker-cluster-medium, .leaflet-oldie .marker-cluster-medium div, 
+.leaflet-oldie .marker-cluster-large, .leaflet-oldie .marker-cluster-large div {
+	background-color: transparent;
+}
+
+@media only screen and (min-width: 769px) {
     #mapid {
       width: 100%;
     }
@@ -49,6 +37,9 @@
     #mapid {
       width: 500px;
       height: 600px;
+    }
+    img {
+      text-align: center;
     }
 }
 

--- a/spana-app/web/IWAD-app/src/app/components/map/map.ts
+++ b/spana-app/web/IWAD-app/src/app/components/map/map.ts
@@ -87,36 +87,9 @@ export class MapCmp implements AfterViewInit {
 
   addMarkers(users) : void {
     console.log('Adding markers');
-    //Clustering settings
-    // var markers = L.markerClusterGroup({
-    //   // disableClusteringAtZoom: 13,
-    //   // spiderfyOnMaxZoom: true,
-    //   chunkedLoading: true,
-    //   maxClusterRadius: function (zoom) {
-    //     return (zoom < 13) ? 100 : 1; // radius in pixels
-    //   }
-    // });
-
-
-    // var childCount = cluster.getChildCount();
-
-		// var c = ' marker-cluster-';
-		// if (childCount < 10) {
-		// 	c += 'small';
-		// } else if (childCount < 100) {
-		// 	c += 'medium';
-		// } else {
-		// 	c += 'large';
-		// }
-
-		// return new L.DivIcon({ html: '<div><span>' + childCount + '</span></div>', className: 'marker-cluster' + c, iconSize: new L.Point(40, 40) });
-	
     var markers = L.markerClusterGroup({
-      
-      
       iconCreateFunction: function(cluster) {
         var childCount = cluster.getChildCount();
-
         var c = ' marker-cluster-';
         if (childCount < 10) {
           c += 'small';
@@ -126,7 +99,7 @@ export class MapCmp implements AfterViewInit {
           c += 'large';
         }
         return new L.DivIcon({ html: '<div><img src="/assets/imgs/heart-icon.png" width="100%"></div>', 
-                                className: 'marker-cluster' + c });
+                                className: 'marker-cluster' + c});
       },
       chunkedLoading: true,
       maxClusterRadius: function (zoom) {

--- a/spana-app/web/IWAD-app/src/app/components/map/map.ts
+++ b/spana-app/web/IWAD-app/src/app/components/map/map.ts
@@ -56,7 +56,7 @@ export class MapCmp implements AfterViewInit {
     this.onMap.emit(this.mymap);
   }
 
-  addMarker(user, color : string) : void {
+  addMarker(user, color : string, markers) : void {
     //Adds a marker in input coordinates, with input color and input id.
     var size = 'l';
     //Options in case we want to change the marker size
@@ -73,24 +73,73 @@ export class MapCmp implements AfterViewInit {
 
     // On click, it will use a service to get the user info and set the popup
     marker.on('click', function(){
-      this.mymap.setView([user.coordinates.lat, user.coordinates.lng], 14);
       if (!marker._popup) {
         this.setPopupText(marker, user);
       }
     }.bind(this));
-    marker.addTo(this.mymap);
     if (this.postId && this.postId == user.key) {
         this.mymap.setView([user.coordinates.lat, user.coordinates.lng], 14);
         this.onMarkersLoad.push(function(){marker.fire("click")});
     }
+    //Add marker to the clustering layer
+    markers.addLayer(marker);
   }
 
   addMarkers(users) : void {
     console.log('Adding markers');
+    //Clustering settings
+    // var markers = L.markerClusterGroup({
+    //   // disableClusteringAtZoom: 13,
+    //   // spiderfyOnMaxZoom: true,
+    //   chunkedLoading: true,
+    //   maxClusterRadius: function (zoom) {
+    //     return (zoom < 13) ? 100 : 1; // radius in pixels
+    //   }
+    // });
+
+
+    // var childCount = cluster.getChildCount();
+
+		// var c = ' marker-cluster-';
+		// if (childCount < 10) {
+		// 	c += 'small';
+		// } else if (childCount < 100) {
+		// 	c += 'medium';
+		// } else {
+		// 	c += 'large';
+		// }
+
+		// return new L.DivIcon({ html: '<div><span>' + childCount + '</span></div>', className: 'marker-cluster' + c, iconSize: new L.Point(40, 40) });
+	
+    var markers = L.markerClusterGroup({
+      
+      
+      iconCreateFunction: function(cluster) {
+        var childCount = cluster.getChildCount();
+
+        var c = ' marker-cluster-';
+        if (childCount < 10) {
+          c += 'small';
+        } else if (childCount < 100) {
+          c += 'medium';
+        } else {
+          c += 'large';
+        }
+        return new L.DivIcon({ html: '<div><img src="/assets/imgs/heart-icon.png" width="100%"></div>', 
+                                className: 'marker-cluster' + c });
+      },
+      chunkedLoading: true,
+      maxClusterRadius: function (zoom) {
+        return (zoom < 13) ? 100 : 1; // radius in pixels
+      }
+    });
+
     //Add a marker for each user
     users.forEach(user => {
-            this.addMarker(user, "f00");
+            this.addMarker(user, "f00", markers);
     });
+    //Add the clustering to the map
+    this.mymap.addLayer(markers);
     console.log('Finished adding markers');
     this.onMarkersLoad.forEach(fn => fn());
   }


### PR DESCRIPTION
Change round clusters for heart icons, same zoom functionality.
Resize map along the screen width for larger screens.
For mobile at home page, align the image to centre and reduce button font size.